### PR TITLE
chore: reinstalling correct fsnotify/fsevents dependency on build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,5 @@
 . ./set_python_home.sh
 export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$PYTHON_HOME/lib/pkgconfig
 set -eu
+go get github.com/fsnotify/fsevents
 go build -buildmode=c-shared -o fsevents_watcher.so


### PR DESCRIPTION
Add correct dependency to the `build.sh` script.